### PR TITLE
fix image permissions issue

### DIFF
--- a/playbooks/testbuild.yml
+++ b/playbooks/testbuild.yml
@@ -33,8 +33,6 @@
         compose_type: "edge-commit"
       register: compose_start_out
 
-    - debug: var=compose_start_out
-
     - name: wait for compose to finish
       osbuild.composer.wait_compose:
         compose_id: "{{ compose_start_out['result']['build_id'] }}"

--- a/playbooks/testbuild.yml
+++ b/playbooks/testbuild.yml
@@ -39,8 +39,15 @@
       osbuild.composer.wait_compose:
         compose_id: "{{ compose_start_out['result']['build_id'] }}"
 
+    - name: Get user info
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ ansible_user }}"
+      register: user_info
+
     - name: export the compose artifact
       osbuild.composer.export_compose:
+        user_id: "{{ user_info['ansible_facts']['getent_passwd'][ansible_user][1] }}"
         compose_id: "{{ compose_start_out['result']['build_id'] }}"
         dest: "/tmp/composer-compose.tar"
 

--- a/playbooks/testbuild.yml
+++ b/playbooks/testbuild.yml
@@ -45,6 +45,7 @@
         dest: "/tmp/composer-compose.tar"
 
     - name: download mycompose.tar
+      become: false
       ansible.posix.synchronize:
         mode: pull
         src: "/tmp/composer-compose.tar"

--- a/plugins/module_utils/weldrapiv1.py
+++ b/plugins/module_utils/weldrapiv1.py
@@ -213,7 +213,8 @@ class WeldrV1(object):
             method="GET",
             unix_socket=self.weldr.unix_socket,
         )
-        os.remove(dest)
+        if os.path.exists(dest):
+            os.remove(dest)
         shutil.copy(tmpfile, dest)
         shutil.chown(dest, user_id, user_id)
         os.remove(tmpfile)

--- a/plugins/module_utils/weldrapiv1.py
+++ b/plugins/module_utils/weldrapiv1.py
@@ -203,7 +203,7 @@ class WeldrV1(object):
         )
         return results
 
-    def get_compose_image(self, compose_uuid, dest):
+    def get_compose_image(self, user_id, compose_uuid, dest):
         """
         # api.router.GET("/api/v:version/compose/image/:uuid", api.composeImageHandler)
         """
@@ -213,8 +213,9 @@ class WeldrV1(object):
             method="GET",
             unix_socket=self.weldr.unix_socket,
         )
+        os.remove(dest)
         shutil.copy(tmpfile, dest)
-        shutil.chown(dest, 1000, 1000)
+        shutil.chown(dest, user_id, user_id)
         os.remove(tmpfile)
 
     ###############################################################################

--- a/plugins/module_utils/weldrapiv1.py
+++ b/plugins/module_utils/weldrapiv1.py
@@ -214,6 +214,7 @@ class WeldrV1(object):
             unix_socket=self.weldr.unix_socket,
         )
         shutil.copy(tmpfile, dest)
+        shutil.chown(dest, 1000, 1000)
         os.remove(tmpfile)
 
     ###############################################################################

--- a/plugins/module_utils/weldrapiv1.py
+++ b/plugins/module_utils/weldrapiv1.py
@@ -151,7 +151,7 @@ class WeldrV1(object):
         )
         return results
 
-    def get_compuse_status(self, compose_uuids):
+    def get_compose_status(self, compose_uuids):
         """
         # api.router.GET("/api/v:version/compose/status/:uuids", api.composeStatusHandler)
         query current status of existing compose

--- a/plugins/modules/export_compose.py
+++ b/plugins/modules/export_compose.py
@@ -26,6 +26,8 @@ options:
     user_id:
         description:
             - UID of the remote system user
+        type: str
+        required: true
     compose_id:
         description:
             - Compose UUID to export

--- a/plugins/modules/export_compose.py
+++ b/plugins/modules/export_compose.py
@@ -23,6 +23,9 @@ description:
 author:
     - Adam Miller (@maxamillion)
 options:
+    user_id:
+        description:
+            - UID of the remote system user
     compose_id:
         description:
             - Compose UUID to export
@@ -38,6 +41,7 @@ options:
 EXAMPLES = """
 - name: Export RHEL for Edge compose
   osbuild.composer.wait_compose:
+    user_id: "1000"
     compose_id: "1bb4cc77-828e-42a2-a3de-9517e99ea4e4"
     dest: "/tmp/mycompose_artifact.tar"
 
@@ -59,6 +63,7 @@ from ansible_collections.osbuild.composer.plugins.module_utils.weldr import Weld
 def main():
     module = AnsibleModule(
         argument_spec=dict(
+            user_id=dict(type="str", required=True),
             compose_id=dict(type="str", required=True),
             dest=dict(type="str", required=True),
         ),
@@ -67,6 +72,7 @@ def main():
     weldr = Weldr(module)
 
     weldr.api.get_compose_image(
+        int(module.params["user_id"]),
         module.params["compose_id"],
         module.params["dest"],
     )

--- a/plugins/modules/export_compose.py
+++ b/plugins/modules/export_compose.py
@@ -22,6 +22,7 @@ description:
     - Export successfully composed image from osbuild-composer service
 author:
     - Adam Miller (@maxamillion)
+    - Matthew Sandoval (@matoval)
 options:
     user_id:
         description:

--- a/roles/builder/vars/main.yml
+++ b/roles/builder/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-pub_key: " ~/.ssh/id_rsa.pub"
+pub_key: "~/.ssh/id_rsa.pub"

--- a/roles/server/tasks/main.yaml
+++ b/roles/server/tasks/main.yaml
@@ -13,6 +13,7 @@
   ansible.builtin.dnf:
     state: latest
     name:
+      - rsync
       - osbuild-composer
       - composer-cli
       - cockpit-composer


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed image pull permissions issue
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The syncronize module creates a new shh connect and does not use Ansible become pass that is passed when running the playbook. This cause an issue when trying to copy a file that is owned by root. 
In order to avoid the permissions issue I changed the owner of the image file which allowed synchronize to copy the file to the local system with become false.

I also installed rsync on the remote system as synchronize requires both local and remote systems to have rsync installed.
