### PR TITLE
Fix image permissions

### DIFF
--- a/playbooks/testbuild.yml
+++ b/playbooks/testbuild.yml
@@ -2,10 +2,15 @@
 - name: test the collection
   hosts: all
   gather_facts: false
-  become: true
   vars:
     blueprint_src_path: "/tmp/testblueprint.toml"
   tasks:
+    - name: Add user to weldr group
+      become: true
+      ansible.builtin.user:
+        name: "{{ ansible_user }}"
+        groups: weldr
+        append: true
     - name: create a blueprint
       osbuild.composer.create_blueprint:
         dest: "{{ blueprint_src_path }}"

--- a/roles/builder/vars/main.yml
+++ b/roles/builder/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-pub_key: " ~/.ssh/id_rsa.pub"
+pub_key: "~/.ssh/id_rsa.pub"

--- a/roles/server/tasks/main.yaml
+++ b/roles/server/tasks/main.yaml
@@ -13,6 +13,7 @@
   ansible.builtin.dnf:
     state: latest
     name:
+      - rsync
       - osbuild-composer
       - composer-cli
       - cockpit-composer


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed image pull permissions issue
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Added user to weldr group to dix permission issue and avoid running as root.

I also installed rsync on the remote system as synchronize requires both local and remote systems to have rsync installed.
