### PR TITLE
created variable for the compose_type 

### DIFF
--- a/roles/builder/defaults/main.yml
+++ b/roles/builder/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for builder
 blueprint_src_path: /tmp/blueprint.toml
+compose_type: edge-simplified-installer

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: start compose
   osbuild.composer.start_compose:
     blueprint: "my-rhel-edge-test"
-    compose_type: "edge-commit"
+    compose_type: "{{ compose_type }}"
   register: compose_start_out
 
 - debug: var=compose_start_out


### PR DESCRIPTION
created variable for the compose_type so we can specify what type of build. also added a default in the default vars to simplified installer

##### SUMMARY
Previously you could not tell what type of build you wanted now you can with the composer_type variable

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request

```
