### PR TITLE
refactor image_server role to use blocks for logic grouping

### DIFF
--- a/roles/image_server/tasks/main.yml
+++ b/roles/image_server/tasks/main.yml
@@ -7,61 +7,59 @@
     state: directory
     mode: '0755'
 
-- name: export the compose artifact
-  osbuild.composer.export_compose:
-    compose_id: "{{ image_uuid['id'] }}"
-    dest: "/tmp/composer-compose-built.iso"
-  when: image_uuid['compose_type'] == "edge-installer"
-
-- name: export the compose artifact
-  osbuild.composer.export_compose:
-    compose_id: "{{ image_uuid['id'] }}"
-    dest: "/tmp/composer-compose-built.tar"
+- name: handle edge-commit/edge-container specific compose_type logic
   when: image_uuid['compose_type'] == "edge-commit" or image_uuid['compose_type'] == "edge-container"
+  block:
+    - name: export the compose artifact
+      osbuild.composer.export_compose:
+        compose_id: "{{ image_uuid['id'] }}"
+        dest: "/tmp/composer-compose-built.tar"
 
-- name: Create directory to hold all image directories
-  ansible.builtin.file:
-    path: /mnt/image_{{ image_uuid['id'] }}
-    state: directory
-    mode: '0755'
+    - name: Copy image file to server dir
+      ansible.builtin.copy:
+        src: /tmp/composer-compose-built.tar
+        dest: /var/www/html/rhel{{ ansible_distribution_major_version }}/images/{{ image_uuid['id'] }}/image_{{ image_uuid['id'] }}.tar
+        remote_src: true
+
+    - name: Extract image commit
+      ansible.builtin.unarchive:
+        src: /var/www/html/rhel{{ ansible_distribution_major_version }}/images/{{ image_uuid['id'] }}/image_{{ image_uuid['id'] }}.tar
+        dest: /var/www/html/rhel{{ ansible_distribution_major_version }}/images/{{ image_uuid['id'] }}
+        remote_src: true
+
+- name: handle edge-installer specific compose_type logic
   when: image_uuid['compose_type'] == "edge-installer"
+  block:
+    - name: export the compose artifact
+      osbuild.composer.export_compose:
+        compose_id: "{{ image_uuid['id'] }}"
+        dest: "/tmp/composer-compose-built.iso"
 
-- name: Copy image file to server dir
-  ansible.builtin.copy:
-    src: /tmp/composer-compose-built.iso
-    dest: /var/www/html/rhel{{ ansible_distribution_major_version }}/images/{{ image_uuid['id'] }}/image_{{ image_uuid['id'] }}.iso
-    remote_src: true
-  when: image_uuid['compose_type'] == "edge-installer"
+    - name: Create directory to hold all image directories
+      ansible.builtin.file:
+        path: /mnt/image_{{ image_uuid['id'] }}
+        state: directory
+        mode: '0755'
 
-- name: Extract image commit
-  ansible.posix.mount:
-    path: /mnt/image_{{ image_uuid['id'] }}
-    src: /var/www/html/rhel{{ ansible_distribution_major_version }}/images/{{ image_uuid['id'] }}/image_{{ image_uuid['id'] }}.iso
-    fstype: iso9660
-    state: mounted
-  when: image_uuid['compose_type'] == "edge-installer"
+    - name: Copy image file to server dir
+      ansible.builtin.copy:
+        src: /tmp/composer-compose-built.iso
+        dest: /var/www/html/rhel{{ ansible_distribution_major_version }}/images/{{ image_uuid['id'] }}/image_{{ image_uuid['id'] }}.iso
+        remote_src: true
 
-- name: copy boot iso files
-  ansible.builtin.copy:
-    src: /mnt/image_{{ image_uuid['id'] }}
-    dest: /var/www/html/rhel{{ ansible_distribution_major_version }}/images/{{ image_uuid['id'] }}/
-    mode: '0755'
-    remote_src: true
-  when: image_uuid['compose_type'] == "edge-installer"
+    - name: Extract image commit
+      ansible.posix.mount:
+        path: /mnt/image_{{ image_uuid['id'] }}
+        src: /var/www/html/rhel{{ ansible_distribution_major_version }}/images/{{ image_uuid['id'] }}/image_{{ image_uuid['id'] }}.iso
+        fstype: iso9660
+        state: mounted
 
-- name: Copy image file to server dir
-  ansible.builtin.copy:
-    src: /tmp/composer-compose-built.tar
-    dest: /var/www/html/rhel{{ ansible_distribution_major_version }}/images/{{ image_uuid['id'] }}/image_{{ image_uuid['id'] }}.tar
-    remote_src: true
-  when: image_uuid['compose_type'] == "edge-commit" or image_uuid['compose_type'] == "edge-container"
-
-- name: Extract image commit
-  ansible.builtin.unarchive:
-    src: /var/www/html/rhel{{ ansible_distribution_major_version }}/images/{{ image_uuid['id'] }}/image_{{ image_uuid['id'] }}.tar
-    dest: /var/www/html/rhel{{ ansible_distribution_major_version }}/images/{{ image_uuid['id'] }}
-    remote_src: true
-  when: image_uuid['compose_type'] == "edge-commit" or image_uuid['compose_type'] == "edge-container"
+    - name: copy boot iso files
+      ansible.builtin.copy:
+        src: /mnt/image_{{ image_uuid['id'] }}
+        dest: /var/www/html/rhel{{ ansible_distribution_major_version }}/images/{{ image_uuid['id'] }}/
+        mode: '0755'
+        remote_src: true
 
 - name: create kickstart file
   ansible.builtin.template:


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
refactor image_server role to use blocks for logic grouping
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

```
